### PR TITLE
Logging tweaks

### DIFF
--- a/credmon/CredentialMonitors/OAuthCredmonWebserver/OAuthCredmonWebserver.py
+++ b/credmon/CredentialMonitors/OAuthCredmonWebserver/OAuthCredmonWebserver.py
@@ -107,7 +107,8 @@ def key(key):
 
         # the local username is global to the session, just grab it from the last classad
         session['local_username'] = provider_ad['LocalUser']
-
+        
+    print('New session started for user {0}'.format(session['local_username']))
     return render_template('index.html')
 
 @app.route('/login/<provider>')
@@ -165,7 +166,6 @@ def oauth_return(provider):
     # gather information from the key file classad
     client_id = provider_ad['ClientId']
     redirect_uri = provider_ad['ReturnUrl']
-    print('session = {0}'.format(session))
     state = session['providers'][provider]['state']
     oauth = OAuth2Session(client_id, state=state, redirect_uri=redirect_uri)
     

--- a/examples/oauth_credmon_webserver
+++ b/examples/oauth_credmon_webserver
@@ -6,10 +6,10 @@ import logging
 
 cred_dir = get_cred_dir()
 logger = setup_logging(log_path = os.path.join(cred_dir, 'oauth_credmon_webserver.log'),
-                           log_level = logging.DEBUG)
+                           log_level = logging.INFO)
 
 if __name__ == '__main__':
     # todo: read flask config from file
     from credmon.CredentialMonitors.OAuthCredmonWebserver import app
     app.secret_key = 'CHANGE THIS IN YOUR IMPLEMENTATION'
-    app.run(use_reloader=False, port=8080, debug=True)
+    app.run(use_reloader=False, port=8080, debug=False)


### PR DESCRIPTION
Some leftover debugging cruft from development meant that the entire session variable was being logged, as well as other secret stuff because of the log level in the example webserver being set to DEBUG. These changes should stop that behavior, at least by default. Resolves #6.