### PR TITLE
Support multiple OAuth tokens from the same provider

### DIFF
--- a/credmon/CredentialMonitors/OAuthCredmonWebserver/OAuthCredmonWebserver.py
+++ b/credmon/CredentialMonitors/OAuthCredmonWebserver/OAuthCredmonWebserver.py
@@ -56,7 +56,7 @@ def get_provider_ad(provider, key_path):
         else:
             raise Exception("Provider {0} not in key file {1}".format(provider, key_path))
 
-    return provider_ad
+    return ad
 
 
 @app.before_request

--- a/credmon/CredentialMonitors/OAuthCredmonWebserver/OAuthCredmonWebserver.py
+++ b/credmon/CredentialMonitors/OAuthCredmonWebserver/OAuthCredmonWebserver.py
@@ -2,7 +2,6 @@ import sys
 from flask import Flask, request, redirect, render_template, session
 from requests_oauthlib import OAuth2Session
 import os
-import pickle
 import tempfile
 from credmon.utils import atomic_rename, get_cred_dir
 import classad

--- a/credmon/CredentialMonitors/OAuthCredmonWebserver/OAuthCredmonWebserver.py
+++ b/credmon/CredentialMonitors/OAuthCredmonWebserver/OAuthCredmonWebserver.py
@@ -148,6 +148,11 @@ def oauth_login(provider):
     providers_dict = session['providers']
     providers_dict[provider]['state'] = state
     session['providers'] = providers_dict
+
+    # store the provider name since it could be different than the provider
+    # argument to oauth_return() (e.g. if getting multiple tokens from the
+    # same OAuth endpoint)
+    session['outgoing_provider'] = provider
     
     return redirect(authorization_url)
 
@@ -157,8 +162,10 @@ def oauth_return(provider):
     Returning from OAuth provider
     """
 
+    # get the provider name from the outgoing_provider set in oauth_login()
+    provider = session.pop('outgoing_provider', provider)
     if not (provider in session['providers']):
-        raise Exception("Provider not in list of providers")
+        raise Exception("Provider {0} not in list of providers".format(provider))
 
     provider_ad = get_provider_ad(provider, session['key_path'])
 

--- a/credmon/CredentialMonitors/OAuthCredmonWebserver/templates/index.html
+++ b/credmon/CredentialMonitors/OAuthCredmonWebserver/templates/index.html
@@ -19,7 +19,7 @@
     <div class="col-12">
       <div class="card" style="width: 20rem;">
         <div class="card-body">
-          <h4 class="card-title">{{ provider }} Login</h4>
+          <h4 class="card-title">{{ ' '.join(provider) }} Login</h4>
           {% if session['providers'][provider]['logged_in'] == True %}
           Logged in as: {{ session['providers'][provider]['username'] }}
           {% else %}

--- a/credmon/CredentialMonitors/OAuthCredmonWebserver/templates/index.html
+++ b/credmon/CredentialMonitors/OAuthCredmonWebserver/templates/index.html
@@ -14,7 +14,7 @@
 </div>
 
 <div class="container">
-  {% for provider in session['providers'] %}
+  {% for provider in sorted(session['providers']) %}
   <div class="row">
     <div class="col-12">
       <div class="card" style="width: 20rem;">

--- a/credmon/CredentialMonitors/OAuthCredmonWebserver/templates/index.html
+++ b/credmon/CredentialMonitors/OAuthCredmonWebserver/templates/index.html
@@ -14,7 +14,7 @@
 </div>
 
 <div class="container">
-  {% for provider in sorted(session['providers']) %}
+  {% for provider in session['providers']|sort %}
   <div class="row">
     <div class="col-12">
       <div class="card" style="width: 20rem;">

--- a/credmon/CredentialMonitors/OAuthCredmonWebserver/templates/index.html
+++ b/credmon/CredentialMonitors/OAuthCredmonWebserver/templates/index.html
@@ -19,7 +19,7 @@
     <div class="col-12">
       <div class="card" style="width: 20rem;">
         <div class="card-body">
-          <h4 class="card-title">{{ ' '.join(provider) }} Login</h4>
+          <h4 class="card-title">{{ provider }} Login</h4>
           {% if session['providers'][provider]['logged_in'] == True %}
           Logged in as: {{ session['providers'][provider]['username'] }}
           {% else %}


### PR DESCRIPTION
This adds support for getting multiple tokens from the same OAuth provider by inspecting and using the `Handle` attribute (if it exists) in the keyfile classad. The tricky part is coming back to the OAuth client-defined return URL, e.g. `/return/box`, because we cannot know from that URL which token request we are returning to. Thus, when going to `/login/<provider>`, we now store the provider (and handle) name in the session when going out to the OAuth authorize endpoint and pop it back out when we come back to our return endpoint. Resolves #5 
