### PR TITLE
Create a 'local credmon' mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,6 @@ SEC_CREDENTIAL_PRODUCER = /var/lib/scitokens-credmon/bin/scitokens_credential_pr
 
 # Path to the private keyfile
 LOCAL_CREDMON_PRIVATE_KEY = /etc/condor/scitokens_ec_private.key
-# Each key must have a name that relying parties can look up.
-LOCAL_CREDMON_PRIVATE_KEY_ID = key-es356
 # The issuer location; relying parties will need to be able to access this issuer to
 # download the corresponding public key.
 LOCAL_CREDMON_ISSUER = https://demo.scitokens.org
@@ -115,5 +113,8 @@ Additionally, the following may be customized
 
 # The lifetime, in seconds, for a new token.  The credmon will continuously renew
 # credentials on the submit-side.
-LOCAL_CREDMON_TOKEN_LIFETIME = 1200
+# LOCAL_CREDMON_TOKEN_LIFETIME = 1200
+
+# Each key must have a name that relying parties can look up; defaults to "local"
+# LOCAL_CREDMON_KEY_ID = key-es356
 ```

--- a/README.md
+++ b/README.md
@@ -91,21 +91,19 @@ In the "local mode", the credmon will use a provided private key to sign a SciTo
 directly, bypassing any OAuth callout.  This is useful in the case where the admin
 wants a less-complex setup than a full OAuth deployment.
 
-To setup the local credmon mode, the following configuration directives are mandatory
+The following configuration directives setup the local credmon mode:
 ```
 # The credential producer invoked by `condor_submit`; causes the credd to be invoked
 # prior to the job being submitted.
 SEC_CREDENTIAL_PRODUCER = /var/lib/scitokens-credmon/bin/scitokens_credential_producer
 
 # Path to the private keyfile
-LOCAL_CREDMON_PRIVATE_KEY = /etc/condor/scitokens_ec_private.key
+# LOCAL_CREDMON_PRIVATE_KEY = /etc/condor/scitokens-private.pem
+
 # The issuer location; relying parties will need to be able to access this issuer to
 # download the corresponding public key.
-LOCAL_CREDMON_ISSUER = https://demo.scitokens.org
-```
+# LOCAL_CREDMON_ISSUER = https://$(FULL_HOSTNAME)
 
-Additionally, the following may be customized
-```
 # The authorizations given to the token.  Should be of the form `authz:path` and
 # space-separated for multiple authorizations.  The token `{username}` will be
 # expanded with the user's Unix username.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ and associated Flask application.
 
 ## Deployment
 
+After installation of the credmon binaries, the admin needs to inform HTCondor of
+the location of the credmon and that it should be run by default.
+
 1. Decide on a directory where credentials (and related CredMon files)
 will be stored. Create the directory owned by the group condor, not
 readable by others, with the SetGID bit set. For example, to create
@@ -47,10 +50,13 @@ the directory under `/var/lib/condor/credentials`:
     drwxrws--- 2 root condor 4096 Jan 23 15:00
     /var/lib/condor/credentials
     ```
-2. Point `condor_config` to the credential directory, the location of
-`condor_credmon`, and to where the CredMon's log file should be written:
+2. On the `condor_schedd` host, add the following
+to a configuration file in `/etc/condor/config.d` or wherever the `$CONDOR_CONFIG` variable
+references:
 	```
-	SEC_CREDENTIAL_DIR = /var/lib/condor/credentials
+	SEC_CREDENTIAL_DIRECTORY = /var/lib/condor/credentials
+    # PYTHONPATH only needs to be set if the credmon is not installed to system Python
+    SEC_CREDENTIAL_MONITOR_ENVIRONMENT = "PYTHONPATH=/var/lib/scitokens-credmon"
     SEC_CREDENTIAL_MONITOR = /usr/bin/condor_credmon
     SEC_CREDENTIAL_MONITOR_LOG = /var/log/condor/CredMon
     ```
@@ -71,3 +77,43 @@ access tokens from.
   authorization endpoint URL and the token endpoint URL.
 5. Configure the Flask application using WSGI in your web server
 config.
+6. On the HTCondor execute hosts, add the following to the configuration file:
+    ```
+    CREDD_OAUTH_MODE = TRUE
+    # NOTE: credd will refuse to transfer tokens on a non-encrypted link.
+    SEC_DEFAULT_ENCRYPTION=REQUIRED
+    ```
+
+Local Credmon Mode
+------------------
+
+In the "local mode", the credmon will use a provided private key to sign a SciToken
+directly, bypassing any OAuth callout.  This is useful in the case where the admin
+wants a less-complex setup than a full OAuth deployment.
+
+To setup the local credmon mode, the following configuration directives are mandatory
+```
+# The credential producer invoked by `condor_submit`; causes the credd to be invoked
+# prior to the job being submitted.
+SEC_CREDENTIAL_PRODUCER = /var/lib/scitokens-credmon/bin/scitokens_credential_producer
+
+# Path to the private keyfile
+LOCAL_CREDMON_PRIVATE_KEY = /etc/condor/scitokens_ec_private.key
+# Each key must have a name that relying parties can look up.
+LOCAL_CREDMON_PRIVATE_KEY_ID = key-es356
+# The issuer location; relying parties will need to be able to access this issuer to
+# download the corresponding public key.
+LOCAL_CREDMON_ISSUER = https://demo.scitokens.org
+```
+
+Additionally, the following may be customized
+```
+# The authorizations given to the token.  Should be of the form `authz:path` and
+# space-separated for multiple authorizations.  The token `{username}` will be
+# expanded with the user's Unix username.
+# LOCAL_CREDMON_AUTHZ_TEMPLATE = read:/user/{username} write:/user/{username}
+
+# The lifetime, in seconds, for a new token.  The credmon will continuously renew
+# credentials on the submit-side.
+LOCAL_CREDMON_TOKEN_LIFETIME = 1200
+```

--- a/bin/condor_credmon
+++ b/bin/condor_credmon
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from credmon import OAuthCredmon
+from credmon import OAuthCredmon, LocalCredmon
 from credmon.utils import setup_logging, get_cred_dir, drop_pid, credmon_incomplete, credmon_complete, create_credentials
 import signal
 import sys
@@ -42,7 +42,8 @@ def main():
     credmon_incomplete(cred_dir)
 
     credmons = [
-        OAuthCredmon()
+        OAuthCredmon(),
+        LocalCredmon()
     ]
 
     # set up scan tokens loop

--- a/bin/scitokens_credential_producer
+++ b/bin/scitokens_credential_producer
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# The only rule of the credential producer is that it can't produce
+# empty stdout.  For SciTokens, this output is ignored and is only used
+# to indicate a token _should_ be produced by the credmon.
+echo "SciTokens credential requets"

--- a/credmon/CredentialMonitors/LocalCredmon.py
+++ b/credmon/CredentialMonitors/LocalCredmon.py
@@ -1,0 +1,99 @@
+
+import os
+import glob
+
+import scitokens
+import htcondor
+
+from credmon.CredentialMonitors.OAuthCredmon import OAuthCredmon
+from credmon.utils import atomic_output_json
+
+class LocalCredmon(OAuthCredmon):
+    """
+    This credential monitor class provides the ability to self-sign SciTokens
+    without needing to access a remote service; only useful when the credd host has
+    a copy of the private signing key.
+    """
+
+    use_token_metadata = True
+
+    def __init__(self, *args, **kwargs):
+        super(LocalCredmon, self).__init__(*args, **kwargs)
+        self.provider = "scitokens"
+        self.token_issuer = "UNKNOWN"
+        self.authz_template = "read:/user/{username} write:/user/{username}"
+        self.token_lifetime = 60*20
+        if htcondor != None:
+            self._private_key_location = htcondor.param.get('LOCAL_CREDMON_PRIVATE_KEY', None)
+            if self._private_key_location != None and os.path.exists(self._private_key_location):
+                with open(self._private_key_location, 'r') as private_key:
+                    self._private_key = private_key.read()
+                self._private_key_id = htcondor.param['LOCAL_CREDMON_PRIVATE_KEY_ID']
+            self.provider = htcondor.param.get("LOCAL_CREDMON_PROVIDER_NAME", "scitokens")
+            self.token_issuer = htcondor.param.get("LOCAL_CREDMON_ISSUER", self.token_issuer)
+            self.authz_template = htcondor.param.get("LOCAL_CREDMON_AUTHZ_TEMPLATE", self.authz_template)
+            self.token_lifetime = htcondor.param.get("LOCAL_CREDMON_TOKEN_LIFETIME", self.token_lifetime)
+        else:
+            self._private_key_location = None
+
+    def refresh_access_token(self, username, token_name):
+        """
+        Create a SciToken at the specified path.
+        """
+
+        token = scitokens.SciToken(algorithm="ES256", key=self._private_key, key_id=self._private_key_id)
+        token.update_claims({'sub': username})
+        user_authz = self.authz_template.format(username=username)
+        token.update_claims({'scp': user_authz})
+
+        # Serialize the token and write it to a file
+        serialized_token = token.serialize(issuer=self.token_issuer, lifetime=self.token_lifetime)
+
+        oauth_response = {"access_token": serialized_token,
+                          "expires_in":   self.token_lifetime}
+
+        access_token_path = os.path.join(self.cred_dir, username, token_name + '.use')
+
+        try:
+            atomic_output_json(oauth_response, access_token_path)
+        except OSError as oe:
+            self.log.exception("Failure when writing out new access token to {}: {}.".format(
+                access_token_path, str(oe)))
+            return False
+        return True
+
+    def process_cred_file(self, cred_fname):
+        """
+        Split out the file path to get username and base.
+        Pass that data to the SciToken acquiring function.
+
+        Format of cred_path should be:
+        <cred_dir> / <username> / <provider>.top
+        """
+        # Take the cred_dir out of the cred_path
+        base, _ = os.path.split(cred_fname)
+        username = os.path.basename(base)
+
+        if self.should_renew(base, username):
+            self.log.info('Found %s, acquiring SciToken and .use file', cred_fname)
+            success = self.refresh_access_token(username, self.provider)
+            if success:
+                self.log.info("Successfully renewed SciToken for user: %s", username)
+            else:
+                self.log.error("Failed to renew SciToken for user: %s", username)
+
+    def scan_tokens(self):
+        """
+        Scan the credential directory for new credential requests.
+
+        The LocalCredmon will look for files of the form `<username>/<provider>.top`
+        and create the corresponding access token files, then invoke the parent OAuthCredmon
+        method.
+        """
+
+        provider_glob = os.path.join(self.cred_dir, "*", "{}.top".format(self.provider))
+
+        for file_name in glob.glob(provider_glob):
+            self.process_cred_file(file_name)
+
+        super(LocalCredmon, self).scan_tokens

--- a/credmon/CredentialMonitors/LocalCredmon.py
+++ b/credmon/CredentialMonitors/LocalCredmon.py
@@ -28,7 +28,7 @@ class LocalCredmon(OAuthCredmon):
             if self._private_key_location != None and os.path.exists(self._private_key_location):
                 with open(self._private_key_location, 'r') as private_key:
                     self._private_key = private_key.read()
-                self._private_key_id = htcondor.param['LOCAL_CREDMON_PRIVATE_KEY_ID']
+                self._private_key_id = htcondor.param.get('LOCAL_CREDMON_KEY_ID', "local")
             self.provider = htcondor.param.get("LOCAL_CREDMON_PROVIDER_NAME", "scitokens")
             self.token_issuer = htcondor.param.get("LOCAL_CREDMON_ISSUER", self.token_issuer)
             self.authz_template = htcondor.param.get("LOCAL_CREDMON_AUTHZ_TEMPLATE", self.authz_template)

--- a/credmon/CredentialMonitors/LocalCredmon.py
+++ b/credmon/CredentialMonitors/LocalCredmon.py
@@ -24,7 +24,7 @@ class LocalCredmon(OAuthCredmon):
         self.authz_template = "read:/user/{username} write:/user/{username}"
         self.token_lifetime = 60*20
         if htcondor != None:
-            self._private_key_location = htcondor.param.get('LOCAL_CREDMON_PRIVATE_KEY', None)
+            self._private_key_location = htcondor.param.get('LOCAL_CREDMON_PRIVATE_KEY', "/etc/condor/scitokens-private.pem")
             if self._private_key_location != None and os.path.exists(self._private_key_location):
                 with open(self._private_key_location, 'r') as private_key:
                     self._private_key = private_key.read()

--- a/credmon/CredentialMonitors/LocalCredmon.py
+++ b/credmon/CredentialMonitors/LocalCredmon.py
@@ -20,7 +20,7 @@ class LocalCredmon(OAuthCredmon):
     def __init__(self, *args, **kwargs):
         super(LocalCredmon, self).__init__(*args, **kwargs)
         self.provider = "scitokens"
-        self.token_issuer = "UNKNOWN"
+        self.token_issuer = None
         self.authz_template = "read:/user/{username} write:/user/{username}"
         self.token_lifetime = 60*20
         if htcondor != None:
@@ -35,6 +35,8 @@ class LocalCredmon(OAuthCredmon):
             self.token_lifetime = htcondor.param.get("LOCAL_CREDMON_TOKEN_LIFETIME", self.token_lifetime)
         else:
             self._private_key_location = None
+        if not self.token_issuer:
+            self.token_issuer = 'https://{}'.format(htcondor.param["FULL_HOSTNAME"])
 
     def refresh_access_token(self, username, token_name):
         """

--- a/credmon/CredentialMonitors/__init__.py
+++ b/credmon/CredentialMonitors/__init__.py
@@ -1,2 +1,3 @@
 from credmon.CredentialMonitors.OAuthCredmon import OAuthCredmon
+from credmon.CredentialMonitors.LocalCredmon import LocalCredmon
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests_oauthlib==1.0.0
 six
 flask
 cryptography
+scitokens

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup(
         'requests_oauthlib==1.0.0',
         'six',
         'flask',
-        'cryptography'
+        'cryptography',
+        'scitokens'
         ],
     include_package_data = True
     )


### PR DESCRIPTION
The local credmon mode generates a SciToken signed by the credmon itself as opposed to calling out via OAuth.

Fixes #2