### PR TITLE
Auto-create a signing key for the local credmon issuer.

### DIFF
--- a/bin/condor_credmon
+++ b/bin/condor_credmon
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from credmon import OAuthCredmon
-from credmon.utils import setup_logging, get_cred_dir, drop_pid, credmon_incomplete, credmon_complete
+from credmon.utils import setup_logging, get_cred_dir, drop_pid, credmon_incomplete, credmon_complete, create_credentials
 import signal
 import sys
 from functools import partial
@@ -28,6 +28,9 @@ def main():
     cred_dir = get_cred_dir()    
     logger = setup_logging()
     logger.info('Starting condor_credmon and registering signals')
+
+    # Try to create the signing credentials for the local credmon.
+    create_credentials()
 
     # catch signals
     signal.signal(signal.SIGHUP, partial(signal_handler, logger))

--- a/credmon/utils/utils.py
+++ b/credmon/utils/utils.py
@@ -49,7 +49,7 @@ def create_credentials():
     public_keyfile = htcondor.param.get("LOCAL_CREDMON_PUBLIC_KEY", "/etc/condor/scitokens.pem")
 
     try:
-        fd = os.open(private_keyfile, os.O_CREAT | os.O_EXCL, 0700)
+        fd = os.open(private_keyfile, os.O_CREAT | os.O_EXCL, 0o700)
     except Exception as exc:
         logger.info("Using existing credential at %s for local signer", private_keyfile)
         return
@@ -74,7 +74,7 @@ def create_credentials():
             encoding=serialization.Encoding.PEM,
             format=serialization.PublicFormat.SubjectPublicKeyInfo
         )
-        atomic_output(public_pem, public_keyfile, mode=0644)
+        atomic_output(public_pem, public_keyfile, mode=0o644)
         logger.info("Successfully creeated a new credential for local credmon at %s", private_keyfile)
     except:
         logger.exception("Failed to create a default private/public keypair; local credmon functionality may not work.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ htcondor
 requests_oauthlib==1.0.0
 six
 flask
-
+cryptography

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ setup(
         'htcondor >= 8.8.0',
         'requests_oauthlib==1.0.0',
         'six',
-        'flask'
+        'flask',
+        'cryptography'
         ],
     include_package_data = True
     )


### PR DESCRIPTION
If the admin has not created her own keys, then this will do it for her; the admin can always place an "official" key later!

Behavior mimics OpenSSH's packaging.