### PR TITLE
Adding example WSGI script

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,11 @@ access tokens from.
   * Consult the OAuth provider API documentation to obtain the
   authorization endpoint URL and the token endpoint URL.
 5. Configure the Flask application using WSGI in your web server
-config.
+configuration. The application should run as a WSGI daemon process
+as user condor and group condor. An example WSGI application script
+is provided in `examples/oauth_credmon.wsgi`. Be sure to modify the
+`app.secret_key` so that user sessions are both secure and persist
+if the web service restarts.
 6. On the HTCondor execute hosts, add the following to the configuration file:
     ```
     CREDD_OAUTH_MODE = TRUE

--- a/examples/oauth_credmon.wsgi
+++ b/examples/oauth_credmon.wsgi
@@ -1,0 +1,10 @@
+from credmon.CredentialMonitors.OAuthCredmonWebserver import app
+
+# Uncomment and change the below to a long, random string.
+# This will enable users' sessions to persist even if the process
+# restarts unexpectedly. Otherwise, a random secret_key will
+# be generated every time the process starts.
+
+#app.secret_key = 'ChangeThisInYourApplication'
+
+application = app


### PR DESCRIPTION
This is only the WSGI application script. Not sure if we should be providing example Apache and nginx configs?

A full Docker implementation should probably live in a different repository.

Resolves #3 