### PR TITLE
Fix non-persistent sessions

### DIFF
--- a/credmon/CredentialMonitors/OAuthCredmonWebserver/OAuthCredmonWebserver.py
+++ b/credmon/CredentialMonitors/OAuthCredmonWebserver/OAuthCredmonWebserver.py
@@ -21,7 +21,7 @@ logger = logging.getLogger('OAuthCredmonWebserver')
 class LoggerWriter:
     '''Used to override sys.stdout and sys.stderr so that
     all messages are sent to the logger'''
-    
+
     def __init__(self, level):
         self.level = level
 
@@ -47,10 +47,10 @@ def get_provider_str(provider, handle):
 
 def get_provider_ad(provider, key_path):
     '''
-    Returns the ClassAd for a given OAuth provider given 
+    Returns the ClassAd for a given OAuth provider given
     the provider name and path to file with ClassAds.
     '''
-    
+
     if not os.path.exists(key_path):
         raise Exception("Key file {0} doesn't exist".format(key_path))
 
@@ -148,16 +148,16 @@ def key(key):
     key_path = os.path.join(cred_dir, key)
     if not os.path.exists(key_path):
         raise Exception("Key file {0} doesn't exist".format(key_path))
-    
+
     # read in the key file, which is a list of classads
     providers = {}
     session['logged_in'] = False
     print('Creating new session from {0}'.format(key_path))
     with open(key_path, 'r') as key_file:
-        
+
         # store the path to the key file since it will be accessed later in the session
         session['key_path'] = key_path
-        
+
         # initialize data for each token provider
         for provider_ad in classad.parseAds(key_file):
             provider = get_provider_str(provider_ad['Provider'], provider_ad.get('Handle', ''))
@@ -181,12 +181,12 @@ def oauth_login(provider):
     Go to OAuth provider
     """
 
-    try:
-        if not (provider in session['providers']):
-            raise Exception("Provider {0} not in list of providers".format(provider))
-    except KeyError:
-        sys.stderr.write("Problem with session dict: {0}\n".format(session))
-        raise
+    if not ('providers' in session):
+        sys.stderr.write('"providers" key was not found in session object: {0}\n'.format(session))
+        raise KeyError('Key "providers" was not found in session object. This session is invalid.')
+    if not (provider in session['providers']):
+        sys.stderr.write('key {0} was not found in session["providers"] dict: {1}\n'.format(provider, session))
+        raise KeyError("Provider {0} was not found in list of providers. This session is invalid.".format(provider))
     provider_ad = get_provider_ad(provider, session['key_path'])
 
     # gather information from the key file classad
@@ -222,7 +222,7 @@ def oauth_login(provider):
     # argument to oauth_return() (e.g. if getting multiple tokens from the
     # same OAuth endpoint)
     session['outgoing_provider'] = provider
-    
+
     return redirect(authorization_url)
 
 @app.route('/return/<provider>')
@@ -233,9 +233,12 @@ def oauth_return(provider):
 
     # get the provider name from the outgoing_provider set in oauth_login()
     provider = session.pop('outgoing_provider', get_provider_str(provider, ''))
+    if not ('providers' in session):
+        sys.stderr.write('"providers" key was not found in session object: {0}\n'.format(session))
+        raise KeyError('Key "providers" was not found in session object. This session is invalid.')
     if not (provider in session['providers']):
-        raise Exception("Provider {0} not in list of providers".format(provider))
-
+        sys.stderr.write('key {0} was not found in session["providers"] dict: {1}\n'.format(provider, session))
+        raise KeyError("Provider {0} was not found in list of providers. This session is invalid.".format(provider))
     provider_ad = get_provider_ad(provider, session['key_path'])
 
     # gather information from the key file classad
@@ -243,7 +246,7 @@ def oauth_return(provider):
     redirect_uri = provider_ad['ReturnUrl']
     state = session['providers'][provider]['state']
     oauth = OAuth2Session(client_id, state=state, redirect_uri=redirect_uri)
-    
+
     # convert http url to https if needed
     if request.url.startswith("http://"):
         updated_url = request.url.replace('http://', 'https://', 1)
@@ -258,7 +261,7 @@ def oauth_return(provider):
         client_secret=client_secret,
         method='POST')
     print('Got {0} token for user {1}'.format(provider, session['local_username']))
-    
+
     # get user info if available
     # todo: make this more generic
     try:
@@ -315,11 +318,11 @@ def oauth_return(provider):
     (tmp_fd, tmp_refresh_token_path) = tempfile.mkstemp(dir = user_cred_dir)
     with os.fdopen(tmp_fd, 'w') as f:
         json.dump(refresh_token, f)
-        
+
     (tmp_fd, tmp_metadata_path) = tempfile.mkstemp(dir = user_cred_dir)
     with os.fdopen(tmp_fd, 'w') as f:
         json.dump(metadata, f)
-        
+
     # (over)write token files
     try:
         atomic_rename(tmp_access_token_path, access_token_path)
@@ -336,6 +339,5 @@ def oauth_return(provider):
     for provider in session['providers']:
         if session['providers'][provider]['logged_in'] == False:
             session['logged_in'] = False
-    
-    return redirect("/")
 
+    return redirect("/")

--- a/credmon/CredentialMonitors/OAuthCredmonWebserver/OAuthCredmonWebserver.py
+++ b/credmon/CredentialMonitors/OAuthCredmonWebserver/OAuthCredmonWebserver.py
@@ -150,29 +150,28 @@ def key(key):
         raise Exception("Key file {0} doesn't exist".format(key_path))
     
     # read in the key file, which is a list of classads
-    session_dict = {}
-    session_dict['providers'] = {}
-    session_dict['logged_in'] = False
+    providers = {}
+    session['logged_in'] = False
     print('Creating new session from {0}'.format(key_path))
     with open(key_path, 'r') as key_file:
         
         # store the path to the key file since it will be accessed later in the session
-        session_dict['key_path'] = key_path
+        session['key_path'] = key_path
         
         # initialize data for each token provider
         for provider_ad in classad.parseAds(key_file):
             provider = get_provider_str(provider_ad['Provider'], provider_ad.get('Handle', ''))
-            session_dict['providers'][provider] = {}
-            session_dict['providers'][provider]['logged_in'] = False
+            providers[provider] = {}
+            providers[provider]['logged_in'] = False
             if 'Scopes' in provider_ad:
-                session_dict['providers'][provider]['requested_scopes'] = [s.rstrip().lstrip() for s in provider_ad['Scopes'].split(',')]
+                providers[provider]['requested_scopes'] = [s.rstrip().lstrip() for s in provider_ad['Scopes'].split(',')]
             if 'Audience' in provider_ad:
-                session_dict['providers'][provider]['requested_resource'] = provider_ad['Audience']
+                providers[provider]['requested_resource'] = provider_ad['Audience']
 
         # the local username is global to the session, just grab it from the last classad
-        session_dict['local_username'] = provider_ad['LocalUser']
+        session['local_username'] = provider_ad['LocalUser']
 
-    session = session_dict
+    session['providers'] = providers
     print('New session started for user {0}'.format(session['local_username']))
     return render_template('index.html')
 

--- a/credmon/utils/utils.py
+++ b/credmon/utils/utils.py
@@ -285,12 +285,7 @@ def generate_secret_key():
         # Use atomic output so the file is only ever read-only
         atomic_output(new_key, keyfile, stat.S_IRUSR)
         logger.info("Successfully created a new persistent WSGI session key for scitokens-credmon application at %s.", keyfile)
-    except Exception:
-        logger.exception("Failed to atomically create a new persistent WSGI session key at %s; will use a transient one.", keyfile)
-        # Attempt to remove the keyfile
-        try:
-            os.unlink(keyfile)
-        except Exception:
-            pass
+    except Exception as e:
+        logger.exception("Failed to atomically create a new persistent WSGI session key at %s (%s); will use a transient one.", keyfile, str(e))
         return new_key
     return new_key

--- a/credmon/utils/utils.py
+++ b/credmon/utils/utils.py
@@ -270,7 +270,7 @@ def generate_secret_key():
     try:
         with open(keyfile, 'rb') as f:
             current_key = f.read(24)
-    except Exception as e:
+    except IOError as e:
         logger.warning("Unable to access WSGI session key at %s (%s); will use a non-persistent key.", keyfile, str(e))
         return os.urandom(16)
 


### PR DESCRIPTION
As reported by Duncan, the current code has some issues with persisting sessions. This PR contains two fixes for this problem:

1. Dictionaries (and other structures) containing session info are now created independently from the `Flask.session` object and then explicitly assigned to the object only after all modifications to the dictionary (or other structure) are done.
2. Fixed a bug in `utils.generate_secret_key()` for the non-existent `wsgi_session_key` file case that caused the function to return early with a non-persistent key instead of first trying to populate a newly created file with a persistent key.