### PR TITLE
Add process 

### DIFF
--- a/bin/scitokens_credmon
+++ b/bin/scitokens_credmon
@@ -6,7 +6,9 @@ from credmon.utils import setup_logging, get_cred_dir, drop_pid, credmon_incompl
 import signal
 import sys
 from functools import partial
-from multiprocessing import Queue, Process
+from multiprocessing import Process
+import multiprocessing
+import Queue
 from optparse import OptionParser, OptionGroup
 import logging
 
@@ -58,7 +60,7 @@ def main():
     create_credentials()
 
     # create queue to end alerts to child to renew
-    send_queue = Queue()
+    send_queue = multiprocessing.Queue()
 
     # catch signals
     signal.signal(signal.SIGHUP, partial(signal_handler, logger, send_queue))

--- a/bin/scitokens_credmon
+++ b/bin/scitokens_credmon
@@ -36,7 +36,7 @@ def signal_handler(logger, send_queue, signum, frame):
     """
     if signum == signal.SIGHUP:
         logger.info('Got SIGHUP: Triggering READ of Credential Directory')
-        send_queue.put(True)
+        send_queue.put(True, False)
         return
     exit_msg = 'Got signal {0} at frame {1} terminating.'
     logger.info(exit_msg.format(signum, frame))

--- a/bin/scitokens_credmon
+++ b/bin/scitokens_credmon
@@ -6,7 +6,7 @@ from credmon.utils import setup_logging, get_cred_dir, drop_pid, credmon_incompl
 import signal
 import sys
 from functools import partial
-from threading import Event
+from multiprocessing import Queue, Process
 from optparse import OptionParser, OptionGroup
 import logging
 
@@ -28,16 +28,15 @@ deploy_options.add_option('--apache', action='store_const',
                               help='Deploy OAuth2 token configuration to Apache')
 parser.add_option_group(deploy_options)
 
-sleeper = Event()
 
-def signal_handler(logger, signum, frame):
+def signal_handler(logger, send_queue, signum, frame):
     """
     Catch signals. Use SIGHUP as a sleep interrupt.
     Any other signals should exit the program.
     """
     if signum == signal.SIGHUP:
         logger.info('Got SIGHUP: Triggering READ of Credential Directory')
-        sleeper.set()
+        send_queue.put(True)
         return
     exit_msg = 'Got signal {0} at frame {1} terminating.'
     logger.info(exit_msg.format(signum, frame))
@@ -58,12 +57,23 @@ def main():
     # Try to create the signing credentials for the local credmon.
     create_credentials()
 
+    # create queue to end alerts to child to renew
+    send_queue = Queue()
+
     # catch signals
-    signal.signal(signal.SIGHUP, partial(signal_handler, logger))
-    signal.signal(signal.SIGTERM, partial(signal_handler, logger))
-    signal.signal(signal.SIGINT, partial(signal_handler, logger))
-    signal.signal(signal.SIGQUIT, partial(signal_handler, logger))
+    signal.signal(signal.SIGHUP, partial(signal_handler, logger, send_queue))
+    signal.signal(signal.SIGTERM, partial(signal_handler, logger, send_queue))
+    signal.signal(signal.SIGINT, partial(signal_handler, logger, send_queue))
+    signal.signal(signal.SIGQUIT, partial(signal_handler, logger, send_queue))
     drop_pid(cred_dir)
+
+    cred_process = Process(target=start_credmon_process, args=(send_queue,cred_dir,logger,))
+    cred_process.start()
+
+    # set up scan tokens loop
+    cred_process.join()
+
+def start_credmon_process(q, cred_dir, logger):
 
     credmon_incomplete(cred_dir)
 
@@ -81,8 +91,10 @@ def main():
                 logger.exception(e)
         credmon_complete(cred_dir)
         logger.info('Sleeping for 60 seconds')
-        sleeper.clear()
-        sleeper.wait(60)
+        try:
+            q.get(True, 60)
+        except Queue.Empty as eq:
+            pass
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
In the experience of running the service, sighup occasionally
causes the credmon to stall.  Run the signal handler in a separate
process to isolate any issues.