### PR TITLE
Delete tokens if not used with some delay

### DIFF
--- a/credmon/CredentialMonitors/OAuthCredmon.py
+++ b/credmon/CredentialMonitors/OAuthCredmon.py
@@ -61,6 +61,16 @@ class OAuthCredmon(AbstractCredentialMonitor):
 
         return False
 
+    def should_delete(self, username, token_name):
+
+        mark_path = os.path.join(self.cred_dir, username, token_name + '.mark')
+
+        # check if mark file exists
+        if os.path.exists(mark_path):
+            return True
+        else:
+            return False
+
     def refresh_access_token(self, username, token_name):
         if OAuth2Session is None:
             raise ImportError("No module named OAuth2Session")
@@ -119,13 +129,38 @@ class OAuthCredmon(AbstractCredentialMonitor):
         else:
             return True
 
+    def delete_tokens(self, username, token_name):
+        exts = ['.top', '.use', '.meta', '.mark']
+        base_path = os.path.join(self.cred_dir, username, token_name)
+
+        success = True
+        for ext in exts:
+            if os.path.exists(base_path + ext):
+                try:
+                    os.unlink(base_path + ext)
+                except OSError as e:
+                    self.log.debug('Could not remove %s: %s', base_path + ext, e.strerror)
+                    success = False
+            else:
+                self.log.debug('Could not find %s', base_path + ext)
+        return success
+
+
     def check_access_token(self, access_token_path):
 
         (basename, token_filename) = os.path.split(access_token_path)
         (cred_dir, username) = os.path.split(basename)
         token_name = os.path.splitext(token_filename)[0] # strip .use
 
-        if self.should_renew(username, token_name):
+        if self.should_delete(username, token_name):
+            self.log.info('%s tokens for user %s are marked for deletion', token_name, username)
+            success = self.delete_tokens(username, token_name)
+            if success:
+                self.log.info('Successfully deleted %s token files for user %s', token_name, username)
+            else:
+                self.log.error('Failed to delete all %s token files for user %s', token_name, username)
+
+        elif self.should_renew(username, token_name):
             self.log.info('Refreshing %s tokens for user %s', token_name, username)
             success = self.refresh_access_token(username, token_name)
             if success:

--- a/credmon/CredentialMonitors/OAuthCredmon.py
+++ b/credmon/CredentialMonitors/OAuthCredmon.py
@@ -74,7 +74,7 @@ class OAuthCredmon(AbstractCredentialMonitor):
                 return False
 
             # if mark file is older than 24 hours, delete tokens
-            self.log.debug('Mark file is %.1f hours old', (time.time() - mtime)/24.)
+            self.log.debug('Mark file is %.1f hours old', (time.time() - mtime)/(60.*60.))
             if time.time() - mtime > 24*60*60:
                 return True
 

--- a/credmon/CredentialMonitors/OAuthCredmon.py
+++ b/credmon/CredentialMonitors/OAuthCredmon.py
@@ -74,6 +74,7 @@ class OAuthCredmon(AbstractCredentialMonitor):
                 return False
 
             # if mark file is older than 24 hours, delete tokens
+            self.log.debug('Mark file is %.1f hours old', (time.time() - mtime)/24.)
             if time.time() - mtime > 24*60*60:
                 return True
 

--- a/credmon/CredentialMonitors/OAuthCredmon.py
+++ b/credmon/CredentialMonitors/OAuthCredmon.py
@@ -81,7 +81,7 @@ class OAuthCredmon(AbstractCredentialMonitor):
             # if mark file is older than 24 hours (or OAUTH_CREDMON_TOKEN_LIFETIME if defined), delete tokens
             self.log.debug('Mark file is %d seconds old', int(time.time() - mtime))
             if htcondor is not None and 'OAUTH_CREDMON_TOKEN_LIFETIME' in htcondor.param:
-                if time.time() - mtime > htcondor.param['OAUTH_CREDMON_TOKEN_LIFETIME']:
+                if time.time() - mtime > int(htcondor.param['OAUTH_CREDMON_TOKEN_LIFETIME']):
                     return True
             elif time.time() - mtime > 24*60*60:
                 return True

--- a/credmon/CredentialMonitors/OAuthCredmon.py
+++ b/credmon/CredentialMonitors/OAuthCredmon.py
@@ -67,9 +67,18 @@ class OAuthCredmon(AbstractCredentialMonitor):
 
         # check if mark file exists
         if os.path.exists(mark_path):
-            return True
-        else:
-            return False
+            try:
+                mtime = os.stat(mark_path).st_mtime
+            except OSError as e:
+                self.log.error('Could not stat %s', mark_path)
+                return False
+
+            # if mark file is older than 24 hours, delete tokens
+            if time.time() - mtime > 24*60*60:
+                return True
+
+        return False
+
 
     def refresh_access_token(self, username, token_name):
         if OAuth2Session is None:


### PR DESCRIPTION
This will require some changes on the credd side, mainly that instead of writing a mark file for a user's entire cred dir, mark files should be written for specific unused credentials.

When this is the case, the OAuthCredmon will now look at the mtime of a mark file, and if it's older than N (at this moment, N = 24 hours), the credmon will remove all tokens associated with the same name as the mark file.

I want to make the delay time configurable before merging this.