### PR TITLE
Fix the documentation and add a more useful test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,8 @@ RUN sed s+__CLIENT_ID__+${SCITOKENS_CLIENT_ID}+g /etc/condor/config.d/60-oauth-t
     chmod 600 /etc/condor/.secrets/scitokens
 
 COPY docker/test.sub /home/${SUBMIT_USER}/test.sub
+COPY docker/test.sh /home/${SUBMIT_USER}/test.sh
 RUN chown ${UID}:${GID} /home/${SUBMIT_USER}/test.sub
+RUN chown ${UID}:${GID} /home/${SUBMIT_USER}/test.sh
 
 CMD ["/usr/sbin/init"]

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Register the client with a Scitokens server. When registering this client, the c
 ```
 https://schedd.client.address:443/return/scitokens
 ```
+You will need to enter one of more audiences and one or more scope request templates for each audience when you register the client. These values will be used to set `scitokens_oauth_resource` and `scitokens_oauth_permissions` in the condor submit file when you run a job.
 
 Record the values of client ID and client secret provided by the server and use them to set the build arguments below.
 
@@ -205,3 +206,28 @@ Edit `docker-compose.yml` to set the `hostname` and `domainname` to be the name 
 docker-compose up --detach
 ```
 
+### Testing the CredMon with the Docker image
+
+The docker container has an unpriveleged user named `submitter` who can submit jobs to the schedd. To log into the container as this user, run the following command from the host:
+```sh
+docker exec -it scitokens-credmon_scitokens-htcondor_1 /bin/su -l submitter
+```
+Once logged in, you will find a submit file names `test.sub`. Edit this file and set the arguments `scitokens_oauth_resource` to one of the audiences that the Schedd is configured to access, and set `scitokens_oauth_permissions` to a valid scope for that audience. For example, of you registered `my.host.org` as an audience with a scope template of `read:/public/**` in the SciTokens server, then
+```
+scitokens_oauth_resource = my.host.org
+scitokens_oauth_permissions = read:/public
+```
+would be valid configurations to get a SciToken for `read:/public` access on `my.host.org`.
+
+Once you have edited the submit file, you can submit it in the usual way with
+```sh
+condor_submit test.sub
+```
+You will provided with a URL to visit the CredMon to authorize the HTCondor to obtain the required SciToken. Once you have done this, you can re-submit the job by running
+```sh
+condor_submit test.sub
+```
+Monitor the statis of the job in the usual way by looking at the job userlog or `condor_q`. Once the job completes, the output file will contain a dump of:
+ * The job environment as printed by `env`. Look for the value of `_CONDOR_CREDS` which is set to the path to the directory where the tokens reside.
+ * A listing of the directory specified by `_CONDOR_CREDS`. Look for a `scitokens.use` file that contains the token.
+ * A dump of all the files in the directory `_CONDOR_CREDS`, including `scitokens.use`. This should contain JSON that contains an `access_token` containing the SciToken itself.

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ SEC_CREDENTIAL_PRODUCER = /usr/bin/scitokens_credential_producer
 # LOCAL_CREDMON_KEY_ID = key-es356
 ```
 
-(#docker-continer-setup)
+## Docker Container Setup
 
 We assume that this container is running with the hostname `schedd.client.address`
 Register the client with a Scitokens server. When registering this client, the callback URL should be
@@ -183,7 +183,7 @@ https://schedd.client.address:443/return/scitokens
 
 Record the values of client ID and client secret provided by the server and use them to set the build arguments below.
 
-## Build the Docker image
+### Build the Docker image
 
 Obtain an X509 host certificate and key pair and put them in the directory
 `docker` in this repository. Then build the image with:
@@ -197,7 +197,7 @@ docker build \
   --rm -t scitokens/htcondor-submit .
 ```
 
-## Run the Docker image
+### Run the Docker image
 
 Edit `docker-compose.yml` to set the `hostname` and `domainname` to be the name of the machine on which this container will run so that it is visible from the outside world.
 

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -v
+
+set -e
+
+echo "=== Job environment ==="
+env
+echo
+
+echo "=== Contents of credential directory ==="
+ls -l ${_CONDOR_CREDS}
+echo
+
+echo "=== Contents of credential files ==="
+for file in ${_CONDOR_CREDS}/*
+do echo "--- ${file} ---" ;
+cat ${file}
+echo
+done
+echo
+
+exit 0

--- a/docker/test.sub
+++ b/docker/test.sub
@@ -4,7 +4,7 @@ output = scitokens_test.$(cluster).$(process).out
 error = scitokens_test.$(cluster).$(process).err
 log = scitokens_test.$(cluster).log
 
-executable = /usr/bin/env
+executable = test.sh
 
 use_oauth_services = scitokens
 


### PR DESCRIPTION
This fixes a couple of typos in the documentation, documents how to test that things are working, and switches the test job from `env` to a small script that dumps the token.