### PR TITLE
Better handle/prevent errors

### DIFF
--- a/bin/condor_credmon_oauth
+++ b/bin/condor_credmon_oauth
@@ -64,8 +64,8 @@ def main():
         for credmon in credmons:
             try:
                 credmon.scan_tokens()
-            except Exception as e:
-                logger.exception(e)
+            except Exception:
+                logger.exception("Fatal error while scanning for tokens")
         credmon_complete(cred_dir)
         logger.info('Sleeping for 60 seconds')
         sleeper.clear()

--- a/credmon/CredentialMonitors/LocalCredmon.py
+++ b/credmon/CredentialMonitors/LocalCredmon.py
@@ -15,7 +15,7 @@ class LocalCredmon(OAuthCredmon):
     a copy of the private signing key.
     """
 
-    use_token_metadata = True
+    use_token_metadata = False
 
     def __init__(self, *args, **kwargs):
         super(LocalCredmon, self).__init__(*args, **kwargs)

--- a/credmon/CredentialMonitors/OAuthCredmon.py
+++ b/credmon/CredentialMonitors/OAuthCredmon.py
@@ -2,7 +2,7 @@ from credmon.CredentialMonitors.AbstractCredentialMonitor import AbstractCredent
 from credmon.utils import atomic_rename
 try:
     from requests_oauthlib import OAuth2Session
-except:
+except ImportError:
     OAuth2Session = None
 import os
 import time
@@ -169,6 +169,12 @@ class OAuthCredmon(AbstractCredentialMonitor):
         (basename, token_filename) = os.path.split(access_token_path)
         (cred_dir, username) = os.path.split(basename)
         token_name = os.path.splitext(token_filename)[0] # strip .use
+
+        # OAuthCredmon only handles OAuth access tokens, which must have metadata files
+        metadata_path = os.path.join(self.cred_dir, username, token_name + '.meta')
+        if not os.path.exists(metadata_path):
+            self.log.debug('Skipping check of %s token files for user %s, no metadata found', token_name, username)
+            return
 
         if self.should_delete(username, token_name):
             self.log.info('%s tokens for user %s are marked for deletion', token_name, username)


### PR DESCRIPTION
1. The OAuthCredmon only looks at tokens with metadata files.
2. Proper usage of logging.exeception in main loop.

I suspect (2) is really the problem causing the credmon to hang, but fixing (1) will prevent the credmon from doing extra work/logging a bunch of extra crap.