### PR TITLE
Add ability to change how soon we refresh tokens for certain providers

### DIFF
--- a/credmon/utils/api_endpoints.py
+++ b/credmon/utils/api_endpoints.py
@@ -16,9 +16,6 @@ def get_token_name(token_url):
 
 def user(token_url):
     '''Returns the URL and fields to query for user info'''
-    token = get_token_name(token_url)
-    if token is None:
-        return (None, None)
 
     url = {
         'box':          'https://api.box.com/2.0/users/me',
@@ -34,4 +31,23 @@ def user(token_url):
         'dropbox':      ['email'],
     }
 
+    token = get_token_name(token_url)
+    if (token is None) or not ((token in url) and (token in field)):
+        return (None, None)
+
     return (url[token], field[token])
+
+def token_lifetime_fraction(token_url):
+    '''Returns the fraction of an access token's lifetime at
+    which point it should be refreshed. Default is 0.5 (the
+    token's "halflife").'''
+
+    lifetime = {
+        'box': 0.95,
+    }
+
+    token = get_token_name(token_url)
+    if (token is None) or not (token in lifetime):
+        return 0.5
+
+    return lifetime[token]


### PR DESCRIPTION
We've observed in CHTC that Box tokens refresh far too quickly... about once every 35 minutes or so. For some providers, refreshing early and often is not a bad idea, however, for Box, only one valid access token can exist at a time, so we should hold off on refreshing it until needed, otherwise execute nodes end up with stale tokens more often.