### PR TITLE
Add hacks to LocalCredmon to work with krb-style tokens

### DIFF
--- a/bin/condor_credmon_oauth
+++ b/bin/condor_credmon_oauth
@@ -1,16 +1,24 @@
 #!/usr/bin/env python
 
-from credmon.CredentialMonitors.OAuthCredmon import OAuthCredmon
-from credmon.CredentialMonitors.LocalCredmon import LocalCredmon
-from credmon.utils import setup_logging, get_cred_dir, drop_pid, credmon_incomplete, credmon_complete, create_credentials
+import os
+import time
 import signal
-import sys
 from functools import partial
 from multiprocessing import Process
 import multiprocessing
-import Queue
+try:
+    import queue as Queue
+except ImportError:
+    import Queue
 from optparse import OptionParser, OptionGroup
 import logging
+
+import htcondor
+import sys
+
+from credmon.CredentialMonitors.OAuthCredmon import OAuthCredmon
+from credmon.CredentialMonitors.LocalCredmon import LocalCredmon
+from credmon.utils import setup_logging, get_cred_dir, drop_pid, credmon_incomplete, credmon_complete, create_credentials
 
 parser = OptionParser()
 parser.add_option('-c', '--cred-dir', action='store', type='string', dest='cred_dir',
@@ -28,14 +36,16 @@ def signal_handler(logger, send_queue, signum, frame):
     """
     if signum == signal.SIGHUP:
         logger.info('Got SIGHUP: Triggering READ of Credential Directory')
-        send_queue.put(True, False)
+        send_queue.put(False, block=False)
         return
     exit_msg = 'Got signal {0} at frame {1} terminating.'
+    send_queue.put(True, block=False)
     logger.info(exit_msg.format(signum, frame))
     sys.exit(0)
 
 def main():
 
+    htcondor.set_subsystem("CREDMON_OAUTH", htcondor.SubsystemType.Daemon)
     (options, args) = parser.parse_args()
 
     cred_dir = get_cred_dir(cred_dir = options.cred_dir)
@@ -55,10 +65,22 @@ def main():
     signal.signal(signal.SIGQUIT, partial(signal_handler, logger, send_queue))
     drop_pid(cred_dir)
 
+    # start the scan tokens loop
     cred_process = Process(target=start_credmon_process, args=(send_queue,cred_dir,logger,))
     cred_process.start()
 
-    # set up scan tokens loop
+    # wait for CREDMON_COMPLETE and signal the condor_master
+    for tries in range(20*60):
+        if os.path.exists(os.path.join(cred_dir, "CREDMON_COMPLETE")):
+            try:
+                logger.info("Sending DC_SET_READY message to master")
+                htcondor.set_ready_state("Ready")
+            except Exception:
+                logger.warning("Could not send DC_SET_READY message to master")
+            break
+        time.sleep(1)
+
+    # join scan tokens loop
     cred_process.join()
 
 def start_credmon_process(q, cred_dir, logger):
@@ -80,7 +102,9 @@ def start_credmon_process(q, cred_dir, logger):
         credmon_complete(cred_dir)
         logger.info('Sleeping for 60 seconds')
         try:
-            q.get(True, 60)
+            credmon_quit = q.get(block=True, timeout=60)
+            if credmon_quit:
+                return
         except Queue.Empty as eq:
             pass
 

--- a/credmon/CredentialMonitors/LocalCredmon.py
+++ b/credmon/CredentialMonitors/LocalCredmon.py
@@ -53,7 +53,7 @@ class LocalCredmon(OAuthCredmon):
         # Serialize the token and write it to a file
         serialized_token = token.serialize(issuer=self.token_issuer, lifetime=int(self.token_lifetime))
 
-        oauth_response = {"access_token": serialized_token,
+        oauth_response = {"access_token": serialized_token.decode(),
                           "expires_in":   int(self.token_lifetime)}
 
         access_token_path = os.path.join(self.cred_dir, username, token_name + '.use')
@@ -78,7 +78,7 @@ class LocalCredmon(OAuthCredmon):
         base, _ = os.path.split(cred_fname)
         username = os.path.basename(base)
 
-        if self.should_renew(base, username):
+        if self.should_renew(username, self.provider):
             self.log.info('Found %s, acquiring SciToken and .use file', cred_fname)
             success = self.refresh_access_token(username, self.provider)
             if success:

--- a/credmon/CredentialMonitors/LocalCredmon.py
+++ b/credmon/CredentialMonitors/LocalCredmon.py
@@ -75,13 +75,20 @@ class LocalCredmon(OAuthCredmon):
         <cred_dir> / <username> / <provider>.top
         """
         # Take the cred_dir out of the cred_path
-        base, _ = os.path.split(cred_fname)
+        if htcondor.param.get("LOCAL_CREDMON_KRB_MODE", False):
+            base = os.path.splitext(cred_fname)[0]
+            if not os.path.isdir(base):
+                os.makedirs(base, mode=0o2755)
+        else:
+            base, _ = os.path.split(cred_fname)
         username = os.path.basename(base)
 
         if self.should_renew(username, self.provider):
             self.log.info('Found %s, acquiring SciToken and .use file', cred_fname)
             success = self.refresh_access_token(username, self.provider)
             if success:
+                if htcondor.param.get("LOCAL_CREDMON_KRB_MODE", False):
+                    shutil.copy(os.path.join(base, self.provider + '.use'), base + '.cc')
                 self.log.info("Successfully renewed SciToken for user: %s", username)
             else:
                 self.log.error("Failed to renew SciToken for user: %s", username)
@@ -96,6 +103,9 @@ class LocalCredmon(OAuthCredmon):
         """
 
         provider_glob = os.path.join(self.cred_dir, "*", "{}.top".format(self.provider))
+        if htcondor.param.get("LOCAL_CREDMON_KRB_MODE", False):
+            provider_glob = os.path.join(self.cred_dir, "*.cred")
+            self.log.info("Looking for *.cred files since LOCAL_CREDMON_KRB_MODE is set, found {} files".format(len(glob.glob(provider_glob))))
 
         for file_name in glob.glob(provider_glob):
             self.process_cred_file(file_name)

--- a/credmon/CredentialMonitors/LocalCredmon.py
+++ b/credmon/CredentialMonitors/LocalCredmon.py
@@ -1,5 +1,6 @@
 
 import os
+import shutil
 import glob
 
 import scitokens

--- a/credmon/CredentialMonitors/OAuthCredmon.py
+++ b/credmon/CredentialMonitors/OAuthCredmon.py
@@ -55,11 +55,13 @@ class OAuthCredmon(AbstractCredentialMonitor):
                 if 'use_refresh_token' in token_metadata:
                     if token_metadata['use_refresh_token'] == False:
                         return False
+            lifetime_fraction = api_endpoints.token_lifetime_fraction(token_metadata['token_url'])
+        else:
+            lifetime_fraction = 0.5
 
         # compute token refresh time
         create_time = os.path.getctime(access_token_path)
-        refresh_time = create_time + (float(access_token['expires_in']) *
-            api_endpoints.token_lifetime_fraction(token_metadata['token_url']))
+        refresh_time = create_time + (float(access_token['expires_in']) * lifetime_fraction)
 
         # check if token is past its refresh time
         if time.time() > refresh_time:

--- a/credmon/CredentialMonitors/OAuthCredmonWebserver/OAuthCredmonWebserver.py
+++ b/credmon/CredentialMonitors/OAuthCredmonWebserver/OAuthCredmonWebserver.py
@@ -10,6 +10,12 @@ import json
 import re
 import logging
 
+from requests_oauthlib import __version__ as _requests_oauthlib_version
+_requests_oauthlib_version = tuple([int(x) for x in _requests_oauthlib_version.split('.')])
+fetch_token_kwargs = {}
+if _requests_oauthlib_version >= (1,2,0):
+    fetch_token_kwargs['include_client_id'] = True
+
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import rsa, ec
@@ -259,7 +265,8 @@ def oauth_return(provider):
     token = oauth.fetch_token(token_url,
         authorization_response=updated_url,
         client_secret=client_secret,
-        method='POST')
+        method='POST',
+        **fetch_token_kwargs)
     print('Got {0} token for user {1}'.format(provider, session['local_username']))
 
     # get user info if available

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 htcondor>=8.8.2
-requests_oauthlib==1.0.0
+requests_oauthlib
 six
 flask
 cryptography

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     scripts = ['bin/condor_credmon_oauth', 'bin/scitokens_credential_producer'],
     install_requires = [
         'htcondor >= 8.8.2',
-        'requests_oauthlib==1.0.0',
+        'requests_oauthlib',
         'six',
         'flask',
         'cryptography',


### PR DESCRIPTION
Since HTCondor 8.9.7's split of OAuth and Kerberos modes,
some of the upstream HTCondor code that the LocalCredmon
depended upon (and that interweaved the two modes) vanished
into the ether, so these hacks allow the LocalCredmon to work
with krb-style token signaling ({username}.cred files) while
we work on re-adding native support for OAuth-style locally
issued tokens.

To be merged after #47 is tested and merged.