### PR TITLE
Change docker-compose up --detach to -d

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ docker build \
 Edit `docker-compose.yml` to set the `hostname` and `domainname` to be the name of the machine on which this container will run so that it is visible from the outside world.
 
 ```
-docker-compose up --detach
+docker-compose up -d
 ```
 
 ### Testing the CredMon with the Docker image


### PR DESCRIPTION
In README, change the docker-compose up `--detach` option to `-d`.  The `--detach` option does not exist in the docker-compose-1.18.0-4 version I got from epel7.