### PR TITLE
Obsolete large chunks of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,21 @@ administrator has configured clients. The CredMon will then monitor
 and refresh these OAuth2 tokens, and HTCondor can use and/or send the
 tokens with users' jobs as requested by the user.
 
+## *** NOTICES ***
+* **Development:** Development of the HTCondor Scitokens CredMon has
+been moved to the [HTCondor source repository](https://github.com/htcondor/htcondor)
+under `src/condor_credd/condor_credmon_oauth`.
+* **Installation:** Starting with [HTCondor version 8.9.9](https://htcondor.readthedocs.io/en/latest/version-history/development-release-series-89.html#version-8-9-9),
+the `condor_credmon_oauth` package should be installed from the
+[HTCondor Enterprise Linux repository](https://research.cs.wisc.edu/htcondor/instructions/).
+Older versions should be uninstalled first.
+* **Documentation:** Set up and administration of the credmon is now
+covered in the [HTCondor Administrator's Manual](https://htcondor.readthedocs.io/en/latest/admin-manual/setting-up-special-environments.html#enabling-the-fetching-and-use-of-oauth2-credentials),
+and usage of OAuth2 credentials is now covered in the [HTCondor User's Manual](https://htcondor.readthedocs.io/en/latest/users-manual/submitting-a-job.html#jobs-that-require-credentials).
+The remaining documentation here covers the local issuer mode of the
+credmon and the Docker image, which are currently undocumented in the
+HTCondor manual.
+
 ### Prerequisites
 
 * HTCondor 8.8.2+
@@ -21,138 +36,6 @@ This repository provides a Docker image for users who want to experiment
 with a personal HTCondor install with the Scitokens CredMon installed.
 For details, see the [instructions for using the Docker
 container](#docker-container-setup) below.
-
-## Installation
-
-On a RHEL-based Linux distributions (RHEL7 only at this time), we
-recommend installing the Scitokens CredMon by first
-[installing and enabling an OSG 3.5+ yum repository](https://opensciencegrid.org/docs/common/yum/),
-and then using `yum` to install the CredMon:
-```sh
-yum install python2-scitokens-credmon
-```
-Or you can grab and install the latest RPM
-[from our GitHub releases](../../releases).
-
-If you use yum or an RPM, example configuration and submit files will
-be stored under
-`/usr/share/doc/python2-scitokens-credmon-%{version}/`.
-
-For other distributions, you can use `pip` to install the latest
-version from GitHub and refer to the
-[example configuration and submit files](examples) inside the GitHub
-repository:
-```sh
-pip install git+https://github.com/htcondor/scitokens-credmon
-```
-Be sure to read the note below about the credential directory.
-
-### Note about the credential directory
-
-If you are installing the CredMon using `pip`, the credential directory
-(`SEC_CREDENTIAL_DIRECTORY_OAUTH = /var/lib/condor/oauth_credentials`
-in the example config file) may need to be manually created and should
-be owned by the group condor with the SetGID bit set and group write
-permissions:
-```sh
-mkdir -p /var/lib/condor/oauth_credentials
-chown root:condor /var/lib/condor/oauth_credentials
-chmod 2770 /var/lib/condor/oauth_credentials
-```
-```
-# ls -ld /var/lib/condor/oauth_credentials
-drwxrws--- 3 root condor 4096 May  8 10:05 /var/lib/condor/oauth_credentials
-```
-
-### Note about daemon-to-daemon encryption
-
-For *both submit and execute hosts*, HTCondor must be configured to
-use encryption for daemon-to-daemon communication. You can check this
-by running `condor_config_val SEC_DEFAULT_ENCRYPTION` on each host,
-which will return `REQUIRED` or `PREFERRED` if encryption is enabled.
-If encryption is not enabled, you should add the following to your HTCondor
-configuration:
-    ```
-    SEC_DEFAULT_ENCRYPTION = REQUIRED
-    ```
-
-## OAuth2 CredMon Mode
-
-### Submit Host Admin Configuration
-
-1. See the
-[example Apache scitokens_credmon.conf config file](examples/config/apache/scitokens_credmon.conf)
-for configuring the OAuth2 Token Flask app. The config must point to a
-WSGI script that imports and runs the Flask app. If you installed the
-CredMon using `pip`, you should use the
-[example scitokens-credmon.wsgi script](examples/wsgi/scitokens-credmon.wsgi).
-RPM-based installs automatically place this script under
-`/var/www/wsgi-scripts/scitokens-credmon`.
-
-2. See the
-[example HTCondor 50-scitokens-credmon.conf config file](examples/config/condor/50-scitokens-credmon.conf)
-for configuring HTCondor with the CredD and CredMon.
-
-3. OAuth2 client information should be added to the submit host HTCondor
-configuration for any OAuth2 providers that you would like your users
-to be able to obtain access tokens from. See the
-[example HTCondor 55-oauth-tokens.conf config file](examples/config/condor/55-oauth-tokens.conf).
-For each provider:
-    * The client id and client secret are generated when you
-    register your submit machine as an application with the
-    OAuth2 provider's API. The client secret must be kept in a file
-    that is only readable by root.
-    * You should configure the return URL in your application's settings
-    as `https://<submit_hostname>/return/<provider>`.
-    * Consult the OAuth2 provider's API documentation to obtain the
-    authorization and token endpoint URLs.
-
-The HTCondor OAuth2 token configuration parameters are:
-```
-<PROVIDER>_CLIENT_ID           The client id string
-<PROVIDER>_CLIENT_SECRET_FILE  Path to the file with the client secret string
-<PROVIDER>_RETURN_URL_SUFFIX   The return URL endpoint for your Flask app ("/return/<provider>")
-<PROVIDER>_AUTHORIZATION_URL   The authorization URL for the OAuth2 provider
-<PROVIDER>_TOKEN_URL           The token URL for the OAuth2 provider
-```
-Multiple OAuth2 clients can be configured as long as unique names are
-used for each `<PROVIDER>`.
-
-Users that request tokens will be directed to a URL on the submit host
-containing a unique key. The Flask app will use this key to generate
-and present a list of token providers and links to log in to each
-provider. Tokens returned from the providers will be stored in the
-`SEC_CREDENTIAL_DIRECTORY_OAUTH` under the users' local usernames, and all
-tokens will be monitored and refreshed as necessary by the OAuth
-CredMon.
-
-### Submit File Commands for Requesting OAuth Tokens
-
-`use_oauth_services = <service1, service2, service3, ...>`
-
-A comma-delimited list of requested OAuth service providers, which
-must match (case-insensitive) the <PROVIDER> names in the submit host
-config.
-
-`<PROVIDER>_oauth_permissions(_<HANDLE>) = <scope1, scope2, scope3, ...>`
-
-A comma-delimited list of requested scopes for the token provided by
-<PROVIDER>. This command is optional if the OAuth provider does not
-require a scope to be defined. A <HANDLE> can optionally be provided
-to give a unique name to the token (useful if requesting differently
-scoped tokens from the same provider).
-
-`<PROVIDER>_oauth_resource(_<HANDLE>) = <resource>`
-
-The resource that the token should request permissions
-for. Currently only required when requesting tokens from a Scitokens
-provider.
-
-When the job executes, tokens are placed in a subdirectory of the job
-sandbox, and can be accessed at
-`$_CONDOR_CREDS/<PROVIDER>(_<HANDLE>).use`.
-
-See [examples/submit](examples/submit) for examples of submit files.
 
 ## Local Credmon Mode
 


### PR DESCRIPTION
As development, releases, and documentation have moved into the
"upstream" HTCondor repository, visitors to the original
GitHUb should be put on notice in the README where to find
whatever it is that they're interested in.